### PR TITLE
Support WRITE_NO_RESPONSE. iOS uses this

### DIFF
--- a/app/src/main/java/jp/co/tracecovid19/bluetooth/gatt/GattService.kt
+++ b/app/src/main/java/jp/co/tracecovid19/bluetooth/gatt/GattService.kt
@@ -14,7 +14,7 @@ class GattService(context: Context, serviceUUIDString: String) {
 
     private var characteristicV2: BluetoothGattCharacteristic = BluetoothGattCharacteristic(
         UUID.fromString(BuildConfig.V2_CHARACTERISTIC_ID),
-        BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_WRITE,
+        BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_WRITE or BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
         BluetoothGattCharacteristic.PERMISSION_READ or BluetoothGattCharacteristic.PERMISSION_WRITE
     )
 


### PR DESCRIPTION
Android実機がなく試せていないですが、これでiOSからwriteできない問題解決しないでしょうか？

iOSではWRITE_NO_RESPONSEを使っています。この方がただのWRITEより多少早いはずです。
