### PR TITLE
都道府県リストを繰り返さないように設定

### DIFF
--- a/app/src/main/java/jp/mamori_i/app/ui/SelectText.kt
+++ b/app/src/main/java/jp/mamori_i/app/ui/SelectText.kt
@@ -58,6 +58,7 @@ class SelectText @JvmOverloads constructor(context: Context, attrs: AttributeSet
         picker.displayedValues = selectDisplaySource()
         picker.minValue = 0
         picker.maxValue = selectDataSource.count() - 1
+        picker.wrapSelectorWheel = false
         picker.descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
         initValue?.let { initValue ->
             picker.value = selectDataSource.indexOf(initValue)


### PR DESCRIPTION
close #29 

SelectorTextに使われているNumberPickerはデフォルトで繰り返すので、`wrapSelectorWheel` を`false`に設定することで繰り返さないようにしました。

![Screenshot_1590024558](https://user-images.githubusercontent.com/932136/82513443-feedb600-9b4d-11ea-8aab-b5cbddc5413c.png)

## 参考
https://stackoverflow.com/questions/13553531/how-to-make-numberpicker-non-recurring