### PR TITLE
PermissionSetting画面でツールバーに戻るボタンを表示する

### DIFF
--- a/app/src/main/java/jp/mamori_i/app/screen/permission/PermissionSettingActivity.kt
+++ b/app/src/main/java/jp/mamori_i/app/screen/permission/PermissionSettingActivity.kt
@@ -58,7 +58,7 @@ class PermissionSettingActivity: AppCompatActivity() {
     }
 
     private fun setupViews() {
-        setUpToolBar(toolBar, "利用いただくために", "", false)
+        setUpToolBar(toolBar, "利用いただくために", "")
         settingButton.setOnClickListener {
             if (enableBluetooth()) {
                 setupPermissionsAndSettings()


### PR DESCRIPTION
close #31

既存のコードで戻るボタンが非表示に設定されていたので、該当の指定を削除しました。

![Screenshot_1590039602](https://user-images.githubusercontent.com/932136/82527289-08d4e080-9b71-11ea-9d7d-18f328979ca9.png)
